### PR TITLE
power-cap: removed APML mux configuration on init

### DIFF
--- a/inc/power_cap.hpp
+++ b/inc/power_cap.hpp
@@ -109,7 +109,6 @@ struct PowerCap
     {
         phosphor::logging::log<phosphor::logging::level::INFO>(
             "PowerCap is created");
-        enableAPMLMuxChannel();
         //init_power_capping();     // init from BMC stored settings
     }
     ~PowerCap()


### PR DESCRIPTION
APML mux need not be configured on BMC reboots.

Signed-off-by: Rajaganesh Rathinasabapathi <Rajaganesh.Rathinasabapathi@amd.com>