### PR TITLE
unbind SBTSI driver when system state change to S5

### DIFF
--- a/inc/power_cap.hpp
+++ b/inc/power_cap.hpp
@@ -95,9 +95,11 @@ struct PowerCap
                         StateServer::Host::HostState currentHostState =
                             StateServer::Host::convertHostStateFromString(
                                 std::get<std::string>(valPropMap->second));
-                        if (currentHostState != StateServer::Host::HostState::Off)
+                        if (currentHostState == StateServer::Host::HostState::Off)
                         {
-
+                            unbindSbtsiDrivers();
+                        }
+                        else {
                             enableAPMLMuxChannel();
                             onHostPwrChange();
                         }
@@ -134,6 +136,10 @@ struct PowerCap
     void onHostPwrChange();
     int  getGPIOValue(const std::string& name);
     void enableAPMLMuxChannel();
+    void setAPMLMux(int cpu);
+    void unbindSbtsiDrivers();
+    void unbindDrivers(int cpu);
+    void bindDrivers(int cpu);
 
     // oob-lib functions
     bool  getPlatformID();

--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -292,14 +292,14 @@ void system_check(char *cmd)
     if ( system(cmd) < 0)
         sd_journal_print(LOG_ERR, "Failed to run system cmd: %s \n", cmd);
 }
-void unbindDrivers(int i)
+void PowerCap::unbindDrivers(int i)
 {
     char cmd[CMD_BUFF_LEN];
 
     // Unbind sbtsi driver
     sprintf(cmd, "echo %d-%llx > %sunbind", I3C_BUS[i], I3C_TSI_DEV, TSI_DRIVER_PATH );
     system_check(cmd);
-    sleep(I3C_WAIT_TIME);
+
     // Unbind platform driver
     if (i == 0)
         sprintf(cmd, "echo %s > %sunbind", I3C_DEV0, I3C_DRIVER_PATH );
@@ -308,7 +308,19 @@ void unbindDrivers(int i)
     system_check(cmd);
     sleep(I3C_WAIT_TIME);
 }
-void bindDrivers(int i)
+void PowerCap::unbindSbtsiDrivers()
+{
+    char cmd[CMD_BUFF_LEN];
+
+    // Unbind sbtsi driver
+    sprintf(cmd, "echo %d-%llx > %sunbind", I3C_BUS[0], I3C_TSI_DEV, TSI_DRIVER_PATH );
+    system_check(cmd);
+    if (num_of_proc == 2) {
+        sprintf(cmd, "echo %d-%llx > %sunbind", I3C_BUS[1], I3C_TSI_DEV, TSI_DRIVER_PATH );
+        system_check(cmd);
+    }
+}
+void PowerCap::bindDrivers(int i)
 {
     char cmd[CMD_BUFF_LEN];
 
@@ -343,7 +355,7 @@ void i3cTransfer(int fd, int len, uint8_t *data )
     //free allocated memory
     free(xfers);
 }
-void setAPMLMux(int i)
+void PowerCap::setAPMLMux(int i)
 {
     int fd;
     char i3c_path[FNAME_LEN];


### PR DESCRIPTION
Signed-off-by: Mohsen Dolaty <mohsen.dolaty@amd.com>