### PR TITLE
Add board ID's to support SP6 platforms

### DIFF
--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -97,6 +97,15 @@ constexpr auto TITANITE_3   = 75;   //0x4B
 constexpr auto TITANITE_4   = 76;   //0x4C
 constexpr auto TITANITE_5   = 77;   //0x4D
 constexpr auto TITANITE_6   = 78;   //0x4E
+
+//SP6 PLATFORMS
+constexpr auto SHALE_1      = 98;   //0x62
+constexpr auto SHALE_2      = 101;  //0x65
+constexpr auto SHALE_3      = 89;   //0x59
+constexpr auto CINNABAR     = 99;   //0x63
+constexpr auto SUNSTONE_1   = 97;   //0x61
+constexpr auto SUNSTONE_2   = 100;  //0x64
+
 constexpr auto I3C_DRIVER_PATH = "/sys/bus/platform/drivers/dw-i3c-master/";
 constexpr auto TSI_DRIVER_PATH = "/sys/bus/i3c/drivers/sbtsi_i3c/";
 constexpr auto RMI_DRIVER_PATH = "/sys/bus/i3c/drivers/sbrmi_i3c/";
@@ -290,6 +299,12 @@ bool PowerCap::getPlatformID()
                 case ONYX_1 ... ONYX_3:
                 case ONYX_FR4:
                 case RUBY_1 ... RUBY_3:
+                case SHALE_1:
+                case SHALE_2:
+                case SHALE_3:
+                case CINNABAR:
+                case SUNSTONE_1:
+                case SUNSTONE_2:
                     num_of_proc = 1;
                     break;
                 case QUARTZ_DAP:


### PR DESCRIPTION
Added board ID's of Shale , Cinnabar and Sunstone platforms 

Signed-off-by: Abinaya <abinaya.dhandapani@amd.com>