### PR TITLE
CPU info does not get populate automatically after Host power off and…

### DIFF
--- a/inc/power_cap.hpp
+++ b/inc/power_cap.hpp
@@ -102,6 +102,7 @@ struct PowerCap
                         else {
                             enableAPMLMuxChannel();
                             onHostPwrChange();
+                            getCPUInformation();
                         }
                     }
                 }
@@ -109,7 +110,6 @@ struct PowerCap
     {
         sd_journal_print(LOG_DEBUG, "PowerCap is created \n");
         getPlatformID();
-	getCPUInformation();
         enableAPMLMuxChannel();
         init_power_capping();     // init from BMC stored settings
     }

--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -138,6 +138,7 @@ void PowerCap::getCPUInformation()
 bool PowerCap::ConnectApml(uint8_t soc_num )
 {
     oob_status_t ret;
+    int retry = 0;
     uint32_t family_id;
     uint32_t model_id;
     uint32_t step_id;
@@ -146,7 +147,20 @@ bool PowerCap::ConnectApml(uint8_t soc_num )
     edx = 0;
     eax = EAX_VAL;
     ecx = 0;
-    ret = esmi_oob_cpuid(soc_num, core_id, &eax, &ebx, &ecx, &edx);
+
+    while(retry < MAX_RETRY)
+    {
+      ret = esmi_oob_cpuid(soc_num, core_id, &eax, &ebx, &ecx, &edx);
+      if(ret != 0)
+      {
+        sleep(10);
+        retry++;
+      }
+      else
+      {
+        break;
+      }
+    }
     if(ret != 0)
     {
       sd_journal_print(LOG_ERR, "apml API -unable to get the CPU value \n");


### PR DESCRIPTION
Fixes: CPU info does not get populate automatically after Host power off and the Host Power ON