### PR TITLE
amd-power-cap: Add flag to indicate APML init complete

### DIFF
--- a/inc/power_cap.hpp
+++ b/inc/power_cap.hpp
@@ -138,10 +138,10 @@ struct PowerCap
     void onHostPwrChange();
     int  getGPIOValue(const std::string& name);
     void enableAPMLMuxChannel();
-    void setAPMLMux(int cpu);
+    int setAPMLMux(int cpu);
     void unbindApmlDrivers();
     void unbindDrivers(int cpu);
-    void bindDrivers(int cpu);
+    int bindDrivers(int cpu);
 
     // oob-lib functions
     bool  getPlatformID();


### PR DESCRIPTION
APML slaves are behind i3c mux in CRB. i3c mux is powered on when host rails are on. Due to this design, we need to bind APML drivers twice. First, to configure mux and second to configure APML slave.

This change adds flag (file) to indicate that binding of APML i3c driver was successful and APML slaves are configured correctly.

Phosphor-pid-control shall wait for this flag (ConditionPathExists) and then query APML based sensors (CPU temp)

Signed-off-by: Rajaganesh Rathinasabapathi <Rajaganesh.Rathinasabapathi@amd.com>