### PR TITLE
Remove incorrect dbus name from amd-power-cap

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,10 +50,6 @@ int main()
     event = nullptr;
 
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
-    sdbusplus::server::manager_t m{bus, DBUS_OBJECT_NAME};
-
-    intfName = DBUS_INTF_NAME;
-    bus.request_name(intfName.c_str());
 
     // Unbind sbtsi and sbrmi drivers
     apml_unbind();


### PR DESCRIPTION
Removed incorrect bus name registration in amd-power-cap application. The object path /xyz/openbmc_project/control/host0/power_cap is already registered with xyz.openbmc_project.Settings and
used by the amd-power-cap application.