### PR TITLE
Bug fix: Get PowerCapEnable property exhausts all the retries

### DIFF
--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -304,7 +304,7 @@ void PowerCap::init_power_capping()
 
     status = get_power_cap_enabled_setting();
 
-    while((status == false) || (retry < MAX_RETRY))
+    while((status == false) && (retry < MAX_RETRY))
     {
         sleep(10); //retry in 10s interval till phosphor-settings service loads
         status = get_power_cap_enabled_setting();


### PR DESCRIPTION
All the 10 retries to get the PowerCapEnable property exhausted which is taking 100 seconds to enable the APML. Fixed the issue which was causing the retries to exhaust.