### PR TITLE
Fix popen return value check

### DIFF
--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -172,7 +172,7 @@ bool PowerCap::get_num_of_proc()
     // variable board_id.
     pf = popen(COMMAND_NUM_OF_CPU,"r");
 
-    if(pf > 0)
+    if(!pf)
     {   // no error
         if (fgets(data, COMMAND_LEN , pf) != NULL)
         {


### PR DESCRIPTION
Fixes the error when trying to build on the latest OpenBMC:

```
| …/src/power_cap.cpp: In member function 'bool PowerCap::get_num_of_proc()':
| …/src/power_cap.cpp:175:11: error: ordered comparison of pointer with integer zero ('FILE*' and 'int')
|   175 |     if(pf > 0)
|       |        ~~~^~~
```

This change has not been tested.
