### PR TITLE
Remove I2C dependencies for sp7 platforms

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,6 @@ extra_libs = [
   '-lstdc++fs',
   '-lphosphor_dbus',
   '-lapml64',
-  '-li2c',
   '-lpthread',
   '-lm'
 ]

--- a/src/power_cap.cpp
+++ b/src/power_cap.cpp
@@ -17,8 +17,6 @@ extern "C"
 #include "apml.h"
 #include "esmi_mailbox.h"
 #include "esmi_rmi.h"
-#include "i2c/smbus.h"
-#include "linux/i2c-dev.h"
 
 #include <unistd.h>
 }


### PR DESCRIPTION
The I2C-related libraries and headers have been
removed from the build and source files since SP7
platforms utilize I3C instead. This cleanup helps
avoid unnecessary dependencies.

Tested field: Build verified with sp7 platform.